### PR TITLE
Implement and provide access to request/response timing information.

### DIFF
--- a/crates/twirp/src/lib.rs
+++ b/crates/twirp/src/lib.rs
@@ -10,7 +10,7 @@ pub mod test;
 
 pub use client::{Client, ClientBuilder, ClientError, Middleware, Next, Result};
 pub use error::*; // many constructors like `invalid_argument()`
-pub use server::{serve, Router};
+pub use server::{serve, Router, Timings};
 
 // Re-export `reqwest` so that it's easy to implement middleware.
 pub use reqwest;


### PR DESCRIPTION
This patch institutes a `Timings` struct and inserts an instance into every request it serves. This work is all written by @tclem; I'm just the one porting it over.