### PR TITLE
Add cargo:rerun-if-changed to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,16 @@ Add a `build.rs` file to your project to compile the protos and generate Rust co
 
 ```rust
 fn main() {
+    let proto_source_files = ["./service.proto"];
+    
+    // Tell Cargo to rerun this build script if any of the proto files change
+    for entry in &proto_source_files {
+        println!("cargo:rerun-if-changed={}", entry);
+    }
+
     prost_build::Config::new()
         .service_generator(twirp_build::service_generator())
-        .compile_protos(&["./service.proto"], &["./"])
+        .compile_protos(&proto_source_files, &["./"])
         .expect("error compiling protos");
 }
 ```


### PR DESCRIPTION
Generally you would want to `cargo:rerun-if-changed` on all your protos
to avoid unnecessary re-runs of the build.rs script. I added it to the
example.
