### PR TITLE
Don't panic if Timings are not provided in the Request

### DIFF
--- a/crates/twirp/src/server.rs
+++ b/crates/twirp/src/server.rs
@@ -51,10 +51,11 @@ where
     Req: prost::Message + Default + serde::de::DeserializeOwned,
     Resp: prost::Message + serde::Serialize,
 {
-    let mut timings = *req
+    let mut timings = req
         .extensions()
         .get::<Timings>()
-        .expect("invariant violated: timing info not present in request");
+        .copied()
+        .unwrap_or_else(|| Timings::new(Instant::now()));
 
     let (req, resp_fmt) = match parse_request(req, &mut timings).await {
         Ok(pair) => pair,


### PR DESCRIPTION
Also adds a test that actually binds the server to the network and tries to talk to it using the client.

This isn't as good as testing the example executables, but it was easy.

Fixes #5.