### PR TITLE
Don't special-case the spelling of `Api`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Define services and messages in a `.proto` file:
 // service.proto
 package service.haberdash.v1;
 
-service HaberdasherApi {
+service HaberdasherAPI {
    rpc MakeHat(MakeHatRequest) returns (MakeHatResponse);
 }
 message MakeHatRequest { }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Define services and messages in a `.proto` file:
 // service.proto
 package service.haberdash.v1;
 
-service HaberdasherAPI {
+service HaberdasherApi {
    rpc MakeHat(MakeHatRequest) returns (MakeHatResponse);
 }
 message MakeHatRequest { }
@@ -64,7 +64,7 @@ use haberdash::{MakeHatRequest, MakeHatResponse};
 
 #[tokio::main]
 pub async fn main() {
-    let api_impl = Arc::new(HaberdasherAPIServer {});
+    let api_impl = Arc::new(HaberdasherApiServer {});
     let twirp_routes = Router::new()
         .nest(haberdash::SERVICE_FQN, haberdash::router(api_impl));
     let app = Router::new()
@@ -78,10 +78,10 @@ pub async fn main() {
 }
 
 // Define the server and implement the trait.
-struct HaberdasherAPIServer;
+struct HaberdasherApiServer;
 
 #[async_trait]
-impl haberdash::HaberdasherAPI for HaberdasherAPIServer {
+impl haberdash::HaberdasherApi for HaberdasherApiServer {
     async fn make_hat(&self, req: MakeHatRequest) -> Result<MakeHatResponse, TwirpErrorResponse> {
         todo!()
     }
@@ -101,7 +101,7 @@ mod haberdash {
     include!(concat!(env!("OUT_DIR"), "/service.haberdash.v1.rs"));
 }
 
-use haberdash::{HaberdasherAPIClient, MakeHatRequest, MakeHatResponse};
+use haberdash::{HaberdasherApiClient, MakeHatRequest, MakeHatResponse};
 
 #[tokio::main]
 pub async fn main() {

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -15,7 +15,7 @@ pub struct ServiceGenerator;
 
 impl prost_build::ServiceGenerator for ServiceGenerator {
     fn generate(&mut self, service: prost_build::Service, buf: &mut String) {
-        let service_name = service.name.replace("Api", "API");
+        let service_name = service.name;
         let service_fqn = format!("{}.{}", service.package, service_name);
         writeln!(buf).unwrap();
 

--- a/crates/twirp/src/details.rs
+++ b/crates/twirp/src/details.rs
@@ -9,7 +9,7 @@ use crate::{server, TwirpErrorResponse};
 
 /// Builder object used by generated code to build a Twirp service.
 ///
-/// The type `S` is something like `Arc<MyExampleAPIServer>`, which can be cheaply cloned for each
+/// The type `S` is something like `Arc<MyExampleApiServer>`, which can be cheaply cloned for each
 /// incoming request, providing access to the Rust value that actually implements the RPCs.
 pub struct TwirpRouterBuilder<S> {
     service: S,
@@ -30,7 +30,7 @@ where
     /// Add a handler for an `rpc` to the router.
     ///
     /// The generated code passes a closure that calls the method, like
-    /// `|api: Arc<HaberdasherAPIServer>, req: MakeHatRequest| async move { api.make_hat(req) }`.
+    /// `|api: Arc<HaberdasherApiServer>, req: MakeHatRequest| async move { api.make_hat(req) }`.
     pub fn route<F, Fut, Req, Res>(self, url: &str, f: F) -> Self
     where
         F: Fn(S, Req) -> Fut + Clone + Sync + Send + 'static,

--- a/crates/twirp/src/test.rs
+++ b/crates/twirp/src/test.rs
@@ -26,17 +26,17 @@ pub async fn run_test_server(port: u16) -> JoinHandle<Result<(), std::io::Error>
 }
 
 pub fn test_api_router() -> Router {
-    let api = Arc::new(TestAPIServer {});
+    let api = Arc::new(TestApiServer {});
 
     // NB: This part would be generated
     let test_router = TwirpRouterBuilder::new(api)
         .route(
             "/Ping",
-            |api: Arc<TestAPIServer>, req: PingRequest| async move { api.ping(req).await },
+            |api: Arc<TestApiServer>, req: PingRequest| async move { api.ping(req).await },
         )
         .route(
             "/Boom",
-            |api: Arc<TestAPIServer>, req: PingRequest| async move { api.boom(req).await },
+            |api: Arc<TestApiServer>, req: PingRequest| async move { api.boom(req).await },
         )
         .build();
 
@@ -75,10 +75,10 @@ pub async fn read_err_body(body: Body) -> TwirpErrorResponse {
 
 // Hand written sample test server and client
 
-pub struct TestAPIServer;
+pub struct TestApiServer;
 
 #[async_trait]
-impl TestAPI for TestAPIServer {
+impl TestApi for TestApiServer {
     async fn ping(&self, req: PingRequest) -> Result<PingResponse, TwirpErrorResponse> {
         Ok(PingResponse { name: req.name })
     }
@@ -90,13 +90,13 @@ impl TestAPI for TestAPIServer {
 
 // Small test twirp services (this would usually be generated with twirp-build)
 #[async_trait]
-pub trait TestAPIClient {
+pub trait TestApiClient {
     async fn ping(&self, req: PingRequest) -> Result<PingResponse>;
     async fn boom(&self, req: PingRequest) -> Result<PingResponse>;
 }
 
 #[async_trait]
-impl TestAPIClient for Client {
+impl TestApiClient for Client {
     async fn ping(&self, req: PingRequest) -> Result<PingResponse> {
         let url = self.base_url.join("test.TestAPI/Ping")?;
         self.request(url, req).await
@@ -108,7 +108,7 @@ impl TestAPIClient for Client {
 }
 
 #[async_trait]
-pub trait TestAPI {
+pub trait TestApi {
     async fn ping(&self, req: PingRequest) -> Result<PingResponse, TwirpErrorResponse>;
     async fn boom(&self, req: PingRequest) -> Result<PingResponse, TwirpErrorResponse>;
 }

--- a/example/src/bin/example-client.rs
+++ b/example/src/bin/example-client.rs
@@ -12,12 +12,12 @@ pub mod service {
     }
 }
 
-use service::haberdash::v1::{HaberdasherAPIClient, MakeHatRequest, MakeHatResponse};
+use service::haberdash::v1::{HaberdasherApiClient, MakeHatRequest, MakeHatResponse};
 
 #[tokio::main]
 pub async fn main() -> Result<(), GenericError> {
     // basic client
-    use service::haberdash::v1::HaberdasherAPIClient;
+    use service::haberdash::v1::HaberdasherApiClient;
     let client = Client::from_base_url(Url::parse("http://localhost:3000/twirp/")?)?;
     let resp = client.make_hat(MakeHatRequest { inches: 1 }).await;
     eprintln!("{:?}", resp);
@@ -70,10 +70,10 @@ impl Middleware for RequestHeaders {
 }
 
 #[derive(Debug)]
-struct MockHaberdasherAPIClient;
+struct MockHaberdasherApiClient;
 
 #[async_trait]
-impl HaberdasherAPIClient for MockHaberdasherAPIClient {
+impl HaberdasherApiClient for MockHaberdasherApiClient {
     async fn make_hat(
         &self,
         _req: MakeHatRequest,

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -21,7 +21,7 @@ async fn ping() -> &'static str {
 
 #[tokio::main]
 pub async fn main() {
-    let api_impl = Arc::new(HaberdasherAPIServer {});
+    let api_impl = Arc::new(HaberdasherApiServer {});
     let twirp_routes = Router::new().nest(haberdash::SERVICE_FQN, haberdash::router(api_impl));
     let app = Router::new()
         .nest("/twirp", twirp_routes)
@@ -38,10 +38,10 @@ pub async fn main() {
     }
 }
 
-struct HaberdasherAPIServer;
+struct HaberdasherApiServer;
 
 #[async_trait]
-impl haberdash::HaberdasherAPI for HaberdasherAPIServer {
+impl haberdash::HaberdasherApi for HaberdasherApiServer {
     async fn make_hat(&self, req: MakeHatRequest) -> Result<MakeHatResponse, TwirpErrorResponse> {
         if req.inches == 0 {
             return Err(invalid_argument("inches"));
@@ -65,18 +65,18 @@ impl haberdash::HaberdasherAPI for HaberdasherAPIServer {
 
 #[cfg(test)]
 mod test {
-    use service::haberdash::v1::HaberdasherAPIClient;
+    use service::haberdash::v1::HaberdasherApiClient;
     use twirp::client::Client;
     use twirp::url::Url;
     use twirp::TwirpErrorCode;
 
-    use crate::service::haberdash::v1::HaberdasherAPI;
+    use crate::service::haberdash::v1::HaberdasherApi;
 
     use super::*;
 
     #[tokio::test]
     async fn success() {
-        let api = HaberdasherAPIServer {};
+        let api = HaberdasherApiServer {};
         let res = api.make_hat(MakeHatRequest { inches: 1 }).await;
         assert!(res.is_ok());
         let res = res.unwrap();
@@ -85,7 +85,7 @@ mod test {
 
     #[tokio::test]
     async fn invalid_request() {
-        let api = HaberdasherAPIServer {};
+        let api = HaberdasherApiServer {};
         let res = api.make_hat(MakeHatRequest { inches: 0 }).await;
         assert!(res.is_err());
         let err = res.unwrap_err();
@@ -100,7 +100,7 @@ mod test {
     }
 
     impl NetServer {
-        async fn start(api_impl: Arc<HaberdasherAPIServer>) -> Self {
+        async fn start(api_impl: Arc<HaberdasherApiServer>) -> Self {
             let twirp_routes =
                 Router::new().nest(haberdash::SERVICE_FQN, haberdash::router(api_impl));
             let app = Router::new()
@@ -143,7 +143,7 @@ mod test {
 
     #[tokio::test]
     async fn test_net() {
-        let api_impl = Arc::new(HaberdasherAPIServer {});
+        let api_impl = Arc::new(HaberdasherApiServer {});
         let server = NetServer::start(api_impl).await;
 
         let url = Url::parse(&format!("http://localhost:{}/twirp/", server.port)).unwrap();


### PR DESCRIPTION
According to @jorendorff, Rust best practices are to avoid capitalizing acronyms.