### PR TITLE
Ensure API is capitalized in service FQNs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,15 +1044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,13 +1298,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -16,7 +16,7 @@ pub struct ServiceGenerator;
 impl prost_build::ServiceGenerator for ServiceGenerator {
     fn generate(&mut self, service: prost_build::Service, buf: &mut String) {
         let service_name = service.name;
-        let service_fqn = format!("{}.{}", service.package, service_name);
+        let service_fqn = format!("{}.{}", service.package, service_name.replace("Api", "API"));
         writeln!(buf).unwrap();
 
         writeln!(buf, "pub const SERVICE_FQN: &str = \"/{service_fqn}\";").unwrap();

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -16,7 +16,7 @@ pub struct ServiceGenerator;
 impl prost_build::ServiceGenerator for ServiceGenerator {
     fn generate(&mut self, service: prost_build::Service, buf: &mut String) {
         let service_name = service.name;
-        let service_fqn = format!("{}.{}", service.package, service_name.replace("Api", "API"));
+        let service_fqn = format!("{}.{}", service.package, service.proto_name);
         writeln!(buf).unwrap();
 
         writeln!(buf, "pub const SERVICE_FQN: &str = \"/{service_fqn}\";").unwrap();


### PR DESCRIPTION
This addresses a bug introduced by #13.