### PR TITLE
Prune dependencies and the features twirp-rs depends on, cargo update, fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,6 +18,6 @@ jobs:
     - name: Install protoc
       run: script/install-protoc
     - name: Build
-      run: cargo build
+      run: make build
     - name: Run tests
-      run: cargo test
+      run: make test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,19 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
-name = "async-compression"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
-dependencies = [
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,15 +191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,16 +262,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flate2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -609,7 +577,6 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "tokio",
- "want",
 ]
 
 [[package]]
@@ -1078,7 +1045,6 @@ version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -1105,7 +1071,6 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/github/twirp-rs"
 default = ["client", "server", "test-support"]
 test-support = ["dep:async-trait", "dep:tokio"]
 client = ["dep:reqwest", "dep:url"]
-server = ["dep:hyper"]
+server = ["dep:axum", "dep:hyper", "dep:tower"]
 
 [dependencies]
 futures = "0.3"
@@ -23,16 +23,16 @@ serde_json = "1.0"
 thiserror = "1.0"
 
 # For the client feature
-reqwest = { version = "0.11", features = ["default", "gzip", "json"], optional = true }
+reqwest = { version = "0.11", default-features = false, optional = true }
 url = { version = "2.5", optional = true }
 
 # For the server feature
-axum = "0.7"
+axum = { version = "0.7", default-features = false, optional = true }
 bytes = "1.5"
 http = "1.0"
 http-body-util = "0.1"
-hyper = { version = "1.1", features = ["full"], optional = true }
-tower = "0.4"
+hyper = { version = "1.1", default-features = false, optional = true }
+tower = { version = "0.4", default-features = false, optional = true }
 
 # For the test-support feature
 async-trait = { version = "0.1", optional = true }

--- a/crates/twirp/src/test.rs
+++ b/crates/twirp/src/test.rs
@@ -18,7 +18,9 @@ use crate::{error, Client, Result, TwirpErrorResponse};
 pub async fn run_test_server(port: u16) -> JoinHandle<Result<(), std::io::Error>> {
     let router = test_api_router();
     let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
-    let tcp_listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    let tcp_listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("failed to bind to local port");
     println!("Listening on {addr}");
     let h = tokio::spawn(async move { axum::serve(tcp_listener, router).await });
     tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
I've better marked which crates are required by `client` vs. `server` features and reduces the features we depend on in each of those dependencies.

I updated CI to run on pull requests and properly call the make targets which fully exercise all the code.

I also ran `cargo update` for good measure. This should address https://github.com/github/twirp-rs/security/dependabot/2