### PR TITLE
Rust 1.76, refactor use of features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -17,7 +17,14 @@ jobs:
       run: script/install-protoc
     - name: Build
       run: make build
-    - name: Lint
-      run: make lint
     - name: Run tests
       run: make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install protoc
+      run: script/install-protoc
+    - name: Lint
+      run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Install protoc
       run: script/install-protoc
     - name: Build
       run: make build
+    - name: Lint
+      run: make lint
     - name: Run tests
       run: make test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,17 +231,13 @@ dependencies = [
 name = "example"
 version = "0.1.0"
 dependencies = [
- "async-trait",
- "axum",
  "fs-err",
  "glob",
- "hyper 0.14.28",
  "prost",
  "prost-build",
  "prost-wkt",
  "prost-wkt-build",
  "prost-wkt-types",
- "reqwest",
  "serde",
  "tokio",
  "twirp",
@@ -265,21 +261,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -578,19 +559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.28",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,12 +631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,24 +693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,50 +725,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "openssl"
-version = "0.10.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -873,12 +773,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "prettyplease"
@@ -1052,23 +946,19 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1097,15 +987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,38 +997,6 @@ name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
-
-[[package]]
-name = "schannel"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "serde"
@@ -1341,16 +1190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,12 +1340,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "want"

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -24,7 +24,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         //
         // generate the twirp server
         //
-        writeln!(buf, "#[async_trait::async_trait]").unwrap();
+        writeln!(buf, "#[twirp::async_trait::async_trait]").unwrap();
         writeln!(buf, "pub trait {} {{", service_name).unwrap();
         for m in &service.methods {
             writeln!(
@@ -70,7 +70,7 @@ where
         // generate the twirp client
         //
         writeln!(buf).unwrap();
-        writeln!(buf, "#[async_trait::async_trait]").unwrap();
+        writeln!(buf, "#[twirp::async_trait::async_trait]").unwrap();
         writeln!(
             buf,
             "pub trait {service_name}Client: Send + Sync + std::fmt::Debug {{",
@@ -88,7 +88,7 @@ where
         writeln!(buf, "}}").unwrap();
 
         // Implement the rpc traits for: `twirp::client::Client`
-        writeln!(buf, "#[async_trait::async_trait]").unwrap();
+        writeln!(buf, "#[twirp::async_trait::async_trait]").unwrap();
         writeln!(
             buf,
             "impl {service_name}Client for twirp::client::Client {{",

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -10,30 +10,21 @@ categories = ["network-programming"]
 repository = "https://github.com/github/twirp-rs"
 
 [features]
-default = ["client", "server", "test-support"]
-test-support = ["dep:async-trait", "dep:tokio"]
-client = ["dep:reqwest", "dep:url"]
-server = ["dep:axum", "dep:hyper", "dep:tower"]
+test-support = []
 
 [dependencies]
+async-trait = "0.1"
+axum = "0.7"
+bytes = "1.5"
 futures = "0.3"
+http = "1.0"
+http-body-util = "0.1"
+hyper = { version = "1.1", default-features = false }
 prost = "0.12"
+reqwest = { version = "0.11", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-
-# For the client feature
-reqwest = { version = "0.11", default-features = false, optional = true }
-url = { version = "2.5", optional = true }
-
-# For the server feature
-axum = { version = "0.7", default-features = false, optional = true }
-bytes = "1.5"
-http = "1.0"
-http-body-util = "0.1"
-hyper = { version = "1.1", default-features = false, optional = true }
-tower = { version = "0.4", default-features = false, optional = true }
-
-# For the test-support feature
-async-trait = { version = "0.1", optional = true }
-tokio = { version = "1.33", features = [], optional = true }
+tokio = { version = "1.33", default-features = false }
+tower = { version = "0.4", default-features = false }
+url = { version = "2.5" }

--- a/crates/twirp/src/lib.rs
+++ b/crates/twirp/src/lib.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "client")]
 pub mod client;
-
 pub mod error;
 pub mod headers;
 pub mod server;
@@ -17,6 +15,7 @@ pub use error::*; // many constructors like `invalid_argument()`
 // Re-export this crate's dependencies that users are likely to code against. These can be used to
 // import the exact versions of these libraries `twirp` is built with -- useful if your project is
 // so sprawling that it builds multiple versions of some crates.
+pub use async_trait;
 pub use axum;
 pub use reqwest;
 pub use tower;

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,20 +5,18 @@ edition = "2021"
 
 [dependencies]
 twirp = { path = "../crates/twirp" }
-async-trait = "0.1"
-axum = "0.7"
-hyper = { version = "0.14", features = ["full"] }
+
 prost = "0.12"
 prost-wkt = "0.5"
 prost-wkt-types = "0.5"
-reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.28", features = ["rt-multi-thread", "macros"] }
 
 [build-dependencies]
+twirp-build = { path = "../crates/twirp-build" }
+
 fs-err = "2.8"
 glob = "0.3.0"
-twirp-build = { path = "../crates/twirp-build" }
 prost-build = "0.12"
 prost-wkt-build = "0.5"
 

--- a/example/src/bin/example-client.rs
+++ b/example/src/bin/example-client.rs
@@ -1,4 +1,4 @@
-use async_trait::async_trait;
+use twirp::async_trait::async_trait;
 use twirp::client::{Client, ClientBuilder, Middleware, Next};
 use twirp::reqwest::{Request, Response};
 use twirp::url::Url;
@@ -25,7 +25,7 @@ pub async fn main() -> Result<(), GenericError> {
     // customize the client with middleware
     let client = ClientBuilder::new(
         Url::parse("http://xyz:3000/twirp/")?,
-        reqwest::Client::default(),
+        twirp::reqwest::Client::default(),
     )
     .with(RequestHeaders { hmac_key: None })
     .build()?;

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -2,8 +2,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
-use async_trait::async_trait;
-use axum::routing::get;
+use twirp::async_trait::async_trait;
+use twirp::axum::routing::get;
 use twirp::{invalid_argument, Router, TwirpErrorResponse};
 
 pub mod service {
@@ -33,7 +33,7 @@ pub async fn main() {
         .await
         .expect("failed to bind");
     println!("Listening on {addr}");
-    if let Err(e) = axum::serve(tcp_listener, app).await {
+    if let Err(e) = twirp::axum::serve(tcp_listener, app).await {
         eprintln!("server error: {}", e);
     }
 }
@@ -120,7 +120,7 @@ mod test {
                 let shutdown_receiver = async move {
                     shutdown_receiver.await.unwrap();
                 };
-                if let Err(e) = axum::serve(tcp_listener, app)
+                if let Err(e) = twirp::axum::serve(tcp_listener, app)
                     .with_graceful_shutdown(shutdown_receiver)
                     .await
                 {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"
 components = [ "rustfmt" ]
 profile = "default"
 


### PR DESCRIPTION
There was an attempt to have a `client` and `server` feature, but the generated code doesn't support this so it's confusing and half implemented. Let's remove it entirely for now.

- Upgrades Rust
- Adds linting to the CI job
- Uses our re-exports of common dependencies which makes it easier to pull in the library and the deps it was built with.