### PR TITLE
Allow passing around req/resp http::Extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twirp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "twirp-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "prost-build",
 ]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add a `build.rs` file to your project to compile the protos and generate Rust co
 ```rust
 fn main() {
     let proto_source_files = ["./service.proto"];
-    
+
     // Tell Cargo to rerun this build script if any of the proto files change
     for entry in &proto_source_files {
         println!("cargo:rerun-if-changed={}", entry);
@@ -82,7 +82,7 @@ struct HaberdasherApiServer;
 
 #[async_trait]
 impl haberdash::HaberdasherApi for HaberdasherApiServer {
-    async fn make_hat(&self, req: MakeHatRequest) -> Result<MakeHatResponse, TwirpErrorResponse> {
+    async fn make_hat(&self, ctx: twirp::Context, req: MakeHatRequest) -> Result<MakeHatResponse, TwirpErrorResponse> {
         todo!()
     }
 }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the `twirp-build` crate as a build dependency in your `Cargo.toml` (you'll n
 ```toml
 # Cargo.toml
 [build-dependencies]
-twirp-build = "0.2"
+twirp-build = "0.3"
 prost-build = "0.12"
 ```
 

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp-build"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The blackbird team <support@github.com>"]
 edition = "2021"
 description = "Code generation for async-compatible Twirp RPC interfaces."

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -29,7 +29,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         for m in &service.methods {
             writeln!(
                 buf,
-                "    async fn {}(&self, req: {}) -> Result<{}, twirp::TwirpErrorResponse>;",
+                "    async fn {}(&self, ctx: twirp::Context, req: {}) -> Result<{}, twirp::TwirpErrorResponse>;",
                 m.name, m.input_type, m.output_type,
             )
             .unwrap();
@@ -52,8 +52,8 @@ where
             let rust_method_name = &m.name;
             writeln!(
                 buf,
-                r#"        .route("/{uri}", |api: std::sync::Arc<T>, req: {req_type}| async move {{
-            api.{rust_method_name}(req).await
+                r#"        .route("/{uri}", |api: std::sync::Arc<T>, ctx: twirp::Context, req: {req_type}| async move {{
+            api.{rust_method_name}(ctx, req).await
         }})"#,
             )
             .unwrap();

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The blackbird team <support@github.com>"]
 edition = "2021"
 description = "An async-compatible library for Twirp RPC in Rust."

--- a/crates/twirp/src/context.rs
+++ b/crates/twirp/src/context.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use http::Extensions;
 
 /// Context allows passing information between twirp rpc handlers and http middleware by providing
-/// access to extensions on the `http:Request` and `http:Response`.
+/// access to extensions on the `http::Request` and `http::Response`.
 ///
 /// An example use case is to extract a request id from an http header and use that id in subsequent
 /// handler code.

--- a/crates/twirp/src/context.rs
+++ b/crates/twirp/src/context.rs
@@ -1,0 +1,42 @@
+use std::sync::{Arc, Mutex};
+
+use http::Extensions;
+
+/// Context allows passing information between twirp rpc handlers and http middleware by providing
+/// access to extensions on the `http:Request` and `http:Response`.
+///
+/// An example use case is to extract a request id from an http header and use that id in subsequent
+/// handler code.
+#[derive(Default)]
+pub struct Context {
+    extensions: Extensions,
+    resp_extensions: Arc<Mutex<Extensions>>,
+}
+
+impl Context {
+    pub fn new(extensions: Extensions, resp_extensions: Arc<Mutex<Extensions>>) -> Self {
+        Self {
+            extensions,
+            resp_extensions,
+        }
+    }
+
+    /// Get a request extension.
+    pub fn get<T>(&self) -> Option<&T>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.extensions.get::<T>()
+    }
+
+    /// Insert a response extension.
+    pub fn insert<T>(&self, val: T) -> Option<T>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.resp_extensions
+            .lock()
+            .expect("mutex poisoned")
+            .insert(val)
+    }
+}

--- a/crates/twirp/src/details.rs
+++ b/crates/twirp/src/details.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use axum::extract::{Request, State};
 use axum::Router;
 
-use crate::{server, TwirpErrorResponse};
+use crate::{server, Context, TwirpErrorResponse};
 
 /// Builder object used by generated code to build a Twirp service.
 ///
@@ -33,7 +33,7 @@ where
     /// `|api: Arc<HaberdasherApiServer>, req: MakeHatRequest| async move { api.make_hat(req) }`.
     pub fn route<F, Fut, Req, Res>(self, url: &str, f: F) -> Self
     where
-        F: Fn(S, Req) -> Fut + Clone + Sync + Send + 'static,
+        F: Fn(S, Context, Req) -> Fut + Clone + Sync + Send + 'static,
         Fut: Future<Output = Result<Res, TwirpErrorResponse>> + Send,
         Req: prost::Message + Default + serde::de::DeserializeOwned,
         Res: prost::Message + serde::Serialize,

--- a/crates/twirp/src/error.rs
+++ b/crates/twirp/src/error.rs
@@ -8,7 +8,7 @@ use http::header::{self, HeaderMap, HeaderValue};
 use hyper::{Response, StatusCode};
 use serde::{Deserialize, Serialize, Serializer};
 
-// Alias for a generic error
+/// Alias for a generic error
 pub type GenericError = Box<dyn std::error::Error + Send + Sync>;
 
 macro_rules! twirp_error_codes {

--- a/crates/twirp/src/lib.rs
+++ b/crates/twirp/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod context;
 pub mod error;
 pub mod headers;
 pub mod server;
@@ -10,7 +11,9 @@ pub mod test;
 pub mod details;
 
 pub use client::{Client, ClientBuilder, ClientError, Middleware, Next, Result};
+pub use context::Context;
 pub use error::*; // many constructors like `invalid_argument()`
+pub use http::Extensions;
 
 // Re-export this crate's dependencies that users are likely to code against. These can be used to
 // import the exact versions of these libraries `twirp` is built with -- useful if your project is

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -102,7 +102,11 @@ async fn request_id_middleware(
 
     let mut res = next.run(request).await;
 
-    let info = res.extensions().get::<ResponseInfo>().unwrap().0;
+    let info = res
+        .extensions()
+        .get::<ResponseInfo>()
+        .expect("must include ResponseInfo")
+        .0;
     res.headers_mut().insert("x-response-info", info.into());
 
     res


### PR DESCRIPTION
Fixes https://github.com/github/twirp-rs/issues/17

Implements a basic way to share data between http middleware (which is dealing with raw `http:Request`/`http::Response`) and twirp RPC handlers (which are primarily concerned with implementing the service's business logic).

🙇🏻 to @nickpresta for some excellent collaboration. Thanks Nick! See https://github.com/github/twirp-rs/issues/17 for the full exploration of the various options for supporting this feature.

NOTE: This is a breaking change. To migrate, users of twirp-rs must add a context param to all methods on their api server implementations. For example, this is the patch in a simple service with one rpc:

```diff
-    async fn make_hat(&self, req: MakeHatRequest) -> Result<MakeHatResponse, TwirpErrorResponse> {
+    async fn make_hat(&self, ctx: twirp::Context, req: MakeHatRequest) -> Result<MakeHatResponse, TwirpErrorResponse> {
```