### PR TITLE
Expose twirp via generated code.

### DIFF
--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -19,6 +19,8 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         let service_fqn = format!("{}.{}", service.package, service.proto_name);
         writeln!(buf).unwrap();
 
+        writeln!(buf, "pub use twirp;").unwrap();
+        writeln!(buf).unwrap();
         writeln!(buf, "pub const SERVICE_FQN: &str = \"/{service_fqn}\";").unwrap();
 
         //


### PR DESCRIPTION
A package that uses `twirp-build` should expose to its downstream users all the types they need. This includes `twirp::Router`, `Client`, `Context`, and `TwirpErrorResponse`. To help users get this right, `twirp-build` generated code now automatically re-exports `twirp`.

The downstream users can still do whatever they were doing, but if they hit the versioning problem described in #38, they now have a fix, namely, change their code to `use haberdash::twirp::Client;` in place of `use twirp::Client;`.

Closes #38.