### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,6 @@ version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
- "bytes",
  "futures",
  "http",
  "http-body-util",

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -15,7 +15,6 @@ test-support = []
 [dependencies]
 async-trait = "0.1"
 axum = "0.7"
-bytes = "1.6"
 futures = "0.3"
 http = "1.0"
 http-body-util = "0.1"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -22,6 +22,9 @@ prost-build = "0.13"
 # TODO: Go back to a true release, waiting on https://github.com/fdeantoni/prost-wkt/pull/68
 prost-wkt-build = { git = "https://github.com/fdeantoni/prost-wkt.git", rev = "0d06c21b24f195fb2bf6e8558111eae9c552f466" }
 
+[package.metadata.cargo-machete]
+ignored = ["prost", "prost-wkt", "serde"]
+
 [[bin]]
 name = "example-client"
 path = "src/bin/example-client.rs"


### PR DESCRIPTION
The `bytes` crate is not needed, I ran `cargo machete` to find this.