### PR TITLE
Add a generic client error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twirp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "twirp-build"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "prost-build",
 ]

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp-build"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The blackbird team <support@github.com>"]
 edition = "2021"
 description = "Code generation for async-compatible Twirp RPC interfaces."

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The blackbird team <support@github.com>"]
 edition = "2021"
 description = "An async-compatible library for Twirp RPC in Rust."

--- a/crates/twirp/src/client.rs
+++ b/crates/twirp/src/client.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use url::Url;
 
 use crate::headers::{CONTENT_TYPE_JSON, CONTENT_TYPE_PROTOBUF};
-use crate::{serialize_proto_message, TwirpErrorResponse};
+use crate::{serialize_proto_message, GenericError, TwirpErrorResponse};
 
 #[derive(Debug, Error)]
 pub enum ClientError {
@@ -36,6 +36,10 @@ pub enum ClientError {
     ReqwestError(#[from] reqwest::Error),
     #[error("twirp error: {0:?}")]
     TwirpError(TwirpErrorResponse),
+
+    /// A generic error that can be used by custom middleware.
+    #[error(transparent)]
+    Generic(#[from] GenericError),
 }
 
 pub type Result<T, E = ClientError> = std::result::Result<T, E>;

--- a/crates/twirp/src/client.rs
+++ b/crates/twirp/src/client.rs
@@ -10,6 +10,7 @@ use crate::headers::{CONTENT_TYPE_JSON, CONTENT_TYPE_PROTOBUF};
 use crate::{serialize_proto_message, GenericError, TwirpErrorResponse};
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ClientError {
     #[error(transparent)]
     InvalidHeader(#[from] InvalidHeaderValue),
@@ -39,7 +40,7 @@ pub enum ClientError {
 
     /// A generic error that can be used by custom middleware.
     #[error(transparent)]
-    Generic(#[from] GenericError),
+    MiddlewareError(#[from] GenericError),
 }
 
 pub type Result<T, E = ClientError> = std::result::Result<T, E>;


### PR DESCRIPTION
Fixes https://github.com/github/twirp-rs/issues/16

I wanted to sketch out a way to allow middleware to return custom errors. What do people think about this approach? @jorendorff?

If we like this, I can add a test and maybe an example usage.