### PR TITLE
Make fields on Timings private, expose total elapsed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twirp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "twirp-build"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "prost-build",
 ]

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp-build"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["The blackbird team <support@github.com>"]
 edition = "2021"
 description = "Code generation for async-compatible Twirp RPC interfaces."

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["The blackbird team <support@github.com>"]
 edition = "2021"
 description = "An async-compatible library for Twirp RPC in Rust."

--- a/crates/twirp/src/server.rs
+++ b/crates/twirp/src/server.rs
@@ -164,15 +164,15 @@ pub async fn not_found_handler() -> Response<Body> {
 #[derive(Debug, Clone, Copy)]
 pub struct Timings {
     // When the request started.
-    pub start: Instant,
+    start: Instant,
     // When the request was received (headers and body).
-    pub request_received: Option<Instant>,
+    request_received: Option<Instant>,
     // When the request body was parsed.
-    pub request_parsed: Option<Instant>,
+    request_parsed: Option<Instant>,
     // When the response handler returned.
-    pub response_handled: Option<Instant>,
+    response_handled: Option<Instant>,
     // When the response was written.
-    pub response_written: Option<Instant>,
+    response_written: Option<Instant>,
 }
 
 impl Timings {
@@ -233,6 +233,11 @@ impl Timings {
             }
             _ => None,
         }
+    }
+
+    /// The total duration since the request started.
+    pub fn total_duration(&self) -> Duration {
+        self.start.elapsed()
     }
 }
 


### PR DESCRIPTION
This is a breaking change, but we had one service that was trying to log/stat the `Instant` values (which isn't very helpful) so I'm proposing to change this so that we only expose durations.