### PR TITLE
Don't require `Client` to be wrapped in `Arc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "twirp-build"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "prost-build",
 ]

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp-build"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["The blackbird team <support@github.com>"]
 edition = "2021"
 description = "Code generation for async-compatible Twirp RPC interfaces."

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -106,11 +106,10 @@ where
             .unwrap();
             writeln!(
                 buf,
-                r#"    let url = self.base_url().join("{}/{}")?;"#,
-                service_fqn, m.proto_name,
+                r#"    self.request("{}/{}", req).await"#,
+                service_fqn, m.proto_name
             )
             .unwrap();
-            writeln!(buf, "    self.request(url, req).await",).unwrap();
             writeln!(buf, "    }}").unwrap();
         }
         writeln!(buf, "}}").unwrap();

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -106,7 +106,7 @@ where
             .unwrap();
             writeln!(
                 buf,
-                r#"    let url = self.base_url.join("{}/{}")?;"#,
+                r#"    let url = self.base_url().join("{}/{}")?;"#,
                 service_fqn, m.proto_name,
             )
             .unwrap();

--- a/crates/twirp/src/client.rs
+++ b/crates/twirp/src/client.rs
@@ -147,10 +147,10 @@ impl Client {
 
     /// Creates a new `twirp::Client` with the same configuration as the current
     /// one, but with a different host in the base URL.
-    pub fn with_host(self, host: &str) -> Self {
+    pub fn with_host(&self, host: &str) -> Self {
         Self {
-            http_client: self.http_client,
-            inner: self.inner,
+            http_client: self.http_client.clone(),
+            inner: self.inner.clone(),
             host: Some(host.to_string()),
         }
     }

--- a/crates/twirp/src/test.rs
+++ b/crates/twirp/src/test.rs
@@ -121,8 +121,7 @@ pub trait TestApiClient {
 #[async_trait]
 impl TestApiClient for Client {
     async fn ping(&self, req: PingRequest) -> Result<PingResponse> {
-        let url = self.base_url().join("test.TestAPI/Ping")?;
-        self.request(url, req).await
+        self.request("test.TestAPI/Ping", req).await
     }
 
     async fn boom(&self, _req: PingRequest) -> Result<PingResponse> {

--- a/crates/twirp/src/test.rs
+++ b/crates/twirp/src/test.rs
@@ -121,7 +121,7 @@ pub trait TestApiClient {
 #[async_trait]
 impl TestApiClient for Client {
     async fn ping(&self, req: PingRequest) -> Result<PingResponse> {
-        let url = self.base_url.join("test.TestAPI/Ping")?;
+        let url = self.base_url().join("test.TestAPI/Ping")?;
         self.request(url, req).await
     }
 

--- a/example/src/bin/example-client.rs
+++ b/example/src/bin/example-client.rs
@@ -31,26 +31,12 @@ pub async fn main() -> Result<(), GenericError> {
     .with(PrintResponseHeaders {})
     .build()?;
     let resp = client
-        .with(hostname("localhost"))
+        .with_host("localhost")
         .make_hat(MakeHatRequest { inches: 1 })
         .await;
     eprintln!("{:?}", resp);
 
     Ok(())
-}
-
-fn hostname(hostname: &str) -> DynamicHostname {
-    DynamicHostname(hostname.to_string())
-}
-struct DynamicHostname(String);
-
-#[async_trait]
-impl Middleware for DynamicHostname {
-    async fn handle(&self, mut req: Request, next: Next<'_>) -> twirp::client::Result<Response> {
-        req.url_mut().set_host(Some(&self.0))?;
-        eprintln!("Set hostname");
-        next.run(req).await
-    }
 }
 
 struct RequestHeaders {


### PR DESCRIPTION
I'd like the `twirp::Client` to behave a little closer to the underly `reqwest::Client` which doesn't require a wrapping `Arc` to reuse.

There is one tricky requirement here that we have over in blackbird - and that is that we dynamically set the hostname per request in one primary use case of this library. I'd previously implemented that as per-request middleware, but that was a bit tricky to get working with the inner `Arc` approach so I've opted for a less generic version of the same functionality.

Breaking change, so I've bumped the version.