### PR TITLE
Don't require `Arc` in `router`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twirp"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "twirp-build"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "prost-build",
 ]

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp-build"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The blackbird team <support@github.com>"]
 edition = "2021"
 description = "Code generation for async-compatible Twirp RPC interfaces."

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -41,9 +41,9 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         // add_service
         writeln!(
             buf,
-            r#"pub fn router<T>(api: std::sync::Arc<T>) -> twirp::Router
+            r#"pub fn router<T>(api: T) -> twirp::Router
 where
-    T: {service_name} + Send + Sync + 'static,
+    T: {service_name} + Clone + Send + Sync + 'static,
 {{
     twirp::details::TwirpRouterBuilder::new(api)"#,
         )
@@ -54,7 +54,7 @@ where
             let rust_method_name = &m.name;
             writeln!(
                 buf,
-                r#"        .route("/{uri}", |api: std::sync::Arc<T>, ctx: twirp::Context, req: {req_type}| async move {{
+                r#"        .route("/{uri}", |api: T, ctx: twirp::Context, req: {req_type}| async move {{
             api.{rust_method_name}(ctx, req).await
         }})"#,
             )

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp"
-version = "0.5.0"
+version = "0.7.0"
 authors = ["The blackbird team <support@github.com>"]
 edition = "2021"
 description = "An async-compatible library for Twirp RPC in Rust."

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,5 +1,4 @@
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
 use twirp::async_trait::async_trait;
@@ -24,7 +23,7 @@ async fn ping() -> &'static str {
 
 #[tokio::main]
 pub async fn main() {
-    let api_impl = Arc::new(HaberdasherApiServer {});
+    let api_impl = HaberdasherApiServer {};
     let middleware = twirp::tower::builder::ServiceBuilder::new()
         .layer(middleware::from_fn(request_id_middleware));
     let twirp_routes = Router::new()
@@ -45,6 +44,7 @@ pub async fn main() {
     }
 }
 
+#[derive(Clone)]
 struct HaberdasherApiServer;
 
 #[async_trait]
@@ -151,7 +151,7 @@ mod test {
     }
 
     impl NetServer {
-        async fn start(api_impl: Arc<HaberdasherApiServer>) -> Self {
+        async fn start(api_impl: HaberdasherApiServer) -> Self {
             let twirp_routes =
                 Router::new().nest(haberdash::SERVICE_FQN, haberdash::router(api_impl));
             let app = Router::new()
@@ -194,7 +194,7 @@ mod test {
 
     #[tokio::test]
     async fn test_net() {
-        let api_impl = Arc::new(HaberdasherApiServer {});
+        let api_impl = HaberdasherApiServer {};
         let server = NetServer::start(api_impl).await;
 
         let url = Url::parse(&format!("http://localhost:{}/twirp/", server.port)).unwrap();


### PR DESCRIPTION
Changes the signature of `router` to generalize to requiring `Clone` instead of forcing wrapping in `Arc`. This enables services to implement their own inner ownership logic.

This is a breaking change.