### PR TITLE
update README: add type serde derive type annotations in prost_build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ fn main() {
     }
 
     prost_build::Config::new()
+        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]") // enable support for JSON encoding
         .service_generator(twirp_build::service_generator())
         .compile_protos(&proto_source_files, &["./"])
         .expect("error compiling protos");


### PR DESCRIPTION
hello. thanks for your work on this crate. i found that the instructions in the README do not compile as written. The issue is that `serde::{Deserialize, Serialize}` are required for all generated types so that the optional JSON encoding can be supported. This requires updating the configuration of `prost_build` to add derive attributes for these traits.