### PR TITLE
stack overflow fix: use fully-qualified T method syntax

### DIFF
--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -50,7 +50,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
                 m.name, m.input_type, m.output_type,
             )
                 .unwrap();
-            writeln!(buf, "        (*self).{}(ctx, req).await", m.name).unwrap();
+            writeln!(buf, "        T::{}(&*self, ctx, req).await", m.name).unwrap();
             writeln!(buf, "    }}").unwrap();
         }
         writeln!(buf, "}}").unwrap();


### PR DESCRIPTION
when using `Arc<HaberdasherApiServer>` from the example in the README, infinite recursion occurs due to the methods in the `impl HaberDasherService for Arc<T: HaberdasherService>` block resolving to a recursive one. By explicitly calling the inner type `T`'s method with the fully qualified method syntax, we can avoid this ambiguity.