### PR TITLE
Use syn/quote for codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,13 @@ dependencies = [
 
 [[package]]
 name = "twirp-build"
-version = "0.8.0"
+version = "0.7.0"
 dependencies = [
+ "prettyplease",
+ "proc-macro2",
  "prost-build",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -16,3 +16,7 @@ license-file = "./LICENSE"
 
 [dependencies]
 prost-build = "0.13"
+prettyplease = { version = "0.2" }
+quote = "1.0"
+syn = "2.0"
+proc-macro2 = "1.0"

--- a/example/proto/haberdash/v1/haberdash_api.proto
+++ b/example/proto/haberdash/v1/haberdash_api.proto
@@ -9,6 +9,7 @@ option go_package = "haberdash.v1";
 service HaberdasherAPI {
   // MakeHat produces a hat of mysterious, randomly-selected color!
   rpc MakeHat(MakeHatRequest) returns (MakeHatResponse);
+  rpc GetStatus(GetStatusRequest) returns (GetStatusResponse);
 }
 
 // Size is passed when requesting a new hat to be made. It's always
@@ -31,4 +32,10 @@ message MakeHatResponse {
 
   // Demonstrate importing an external message.
   google.protobuf.Timestamp timestamp = 4;
+}
+
+message GetStatusRequest {}
+
+message GetStatusResponse {
+    string status = 1;
 }

--- a/example/src/bin/advanced-server.rs
+++ b/example/src/bin/advanced-server.rs
@@ -17,7 +17,9 @@ pub mod service {
         }
     }
 }
-use service::haberdash::v1::{self as haberdash, MakeHatRequest, MakeHatResponse};
+use service::haberdash::v1::{
+    self as haberdash, GetStatusRequest, GetStatusResponse, MakeHatRequest, MakeHatResponse,
+};
 
 async fn ping() -> &'static str {
     "Pong\n"
@@ -93,6 +95,16 @@ impl haberdash::HaberdasherApi for HaberdasherApiServer {
                 seconds: ts.as_secs() as i64,
                 nanos: 0,
             }),
+        })
+    }
+
+    async fn get_status(
+        &self,
+        _ctx: Context,
+        _req: GetStatusRequest,
+    ) -> Result<GetStatusResponse, HatError> {
+        Ok(GetStatusResponse {
+            status: "making hats".to_string(),
         })
     }
 }

--- a/example/src/bin/client.rs
+++ b/example/src/bin/client.rs
@@ -12,7 +12,9 @@ pub mod service {
     }
 }
 
-use service::haberdash::v1::{HaberdasherApiClient, MakeHatRequest, MakeHatResponse};
+use service::haberdash::v1::{
+    GetStatusRequest, GetStatusResponse, HaberdasherApiClient, MakeHatRequest, MakeHatResponse,
+};
 
 #[tokio::main]
 pub async fn main() -> Result<(), GenericError> {
@@ -77,6 +79,13 @@ impl HaberdasherApiClient for MockHaberdasherApiClient {
         &self,
         _req: MakeHatRequest,
     ) -> Result<MakeHatResponse, twirp::client::ClientError> {
+        todo!()
+    }
+
+    async fn get_status(
+        &self,
+        _req: GetStatusRequest,
+    ) -> Result<GetStatusResponse, twirp::client::ClientError> {
         todo!()
     }
 }

--- a/example/src/bin/simple-server.rs
+++ b/example/src/bin/simple-server.rs
@@ -12,7 +12,9 @@ pub mod service {
         }
     }
 }
-use service::haberdash::v1::{self as haberdash, MakeHatRequest, MakeHatResponse};
+use service::haberdash::v1::{
+    self as haberdash, GetStatusRequest, GetStatusResponse, MakeHatRequest, MakeHatResponse,
+};
 
 async fn ping() -> &'static str {
     "Pong\n"
@@ -67,6 +69,16 @@ impl haberdash::HaberdasherApi for HaberdasherApiServer {
                 seconds: ts.as_secs() as i64,
                 nanos: 0,
             }),
+        })
+    }
+
+    async fn get_status(
+        &self,
+        _ctx: Context,
+        _req: GetStatusRequest,
+    ) -> Result<GetStatusResponse, TwirpErrorResponse> {
+        Ok(GetStatusResponse {
+            status: "making hats".to_string(),
         })
     }
 }


### PR DESCRIPTION
First of all, thanks for maintaining this crate. It's been really easy to get started with and to use .

I had some ideas for changing how code was generated for services, but wanted to make it easier to change things before I started messing around. I borrowed the `syn`/`quote`/`prettyplease` approach from `tonic` because I find the quasi-quoted codegen a lot easier to read than template strings to `write!` - here's an [example of some heavy quote usage in tonic-build](https://github.com/hyperium/tonic/blob/master/tonic-build/src/server.rs#L95-L121).

For this PR I tried to keep the structure of `lib.rs` mostly the same. I'm happy to break it up a bit or get a little more disciplined about idents and types if y'all are interested but I didn't want to presume too much.