### PR TITLE
Release v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,7 +1236,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twirp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "twirp-build"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp-build"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Code generation for async-compatible Twirp RPC interfaces."
 readme = "README.md"

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -11,7 +11,6 @@ categories = [
     "asynchronous",
 ]
 repository = "https://github.com/github/twirp-rs"
-license = "MIT"
 license-file = "./LICENSE"
 
 [dependencies]

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "An async-compatible library for Twirp RPC in Rust."
 readme = "README.md"

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -11,7 +11,6 @@ categories = [
     "asynchronous",
 ]
 repository = "https://github.com/github/twirp-rs"
-license = "MIT"
 license-file = "./LICENSE"
 
 [features]


### PR DESCRIPTION
This PR has already been published to crates.io as [twirp 0.8.0](https://crates.io/crates/twirp/0.8.0) and [twirp-build 0.8.0](https://crates.io/crates/twirp-build/0.8.0).

