### PR TITLE
Bump protoc version from 3.17.0 to 21.0

### DIFF
--- a/script/install-protoc
+++ b/script/install-protoc
@@ -24,7 +24,7 @@ fi
 echo "Installing protoc..."
 
 # Download protoc
-protoc_version="3.17.0"
+protoc_version="21.0"
 protoc_os="osx-x86_64"
 if [[ $OSTYPE == linux* ]]; then
     protoc_os="linux-x86_64"


### PR DESCRIPTION
- Fixes Issue #157.
- Protoc version 21.0 was specifically chosen for Ubuntu 24.04 (Noble Number).