### PR TITLE
WIP: Use a request builder pattern to allow clients to set headers and other per-request info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,10 +1291,8 @@ name = "twirp-build"
 version = "0.8.0"
 dependencies = [
  "prettyplease",
- "proc-macro2",
  "prost-build",
  "quote",
- "reqwest",
  "syn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,6 +1294,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
+ "reqwest",
  "syn",
 ]
 

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -16,7 +16,5 @@ license-file = "./LICENSE"
 [dependencies]
 prost-build = "0.13"
 prettyplease = { version = "0.2" }
-reqwest = { version = "0.12", default-features = false }
 quote = "1.0"
 syn = "2.0"
-proc-macro2 = "1.0"

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -16,6 +16,7 @@ license-file = "./LICENSE"
 [dependencies]
 prost-build = "0.13"
 prettyplease = { version = "0.2" }
+reqwest = { version = "0.12", default-features = false }
 quote = "1.0"
 syn = "2.0"
 proc-macro2 = "1.0"

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -164,34 +164,6 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         let client_name = service.client_name;
         let mut client_trait_methods = Vec::with_capacity(service.methods.len());
         let mut client_methods = Vec::with_capacity(service.methods.len());
-        client_trait_methods.push(quote! {
-            async fn request<I, O>(&self, req: twirp::RequestBuilder<I, O>) -> Result<O, twirp::ClientError>
-            where
-                I: prost::Message,
-                O: prost::Message + Default;
-        });
-        client_trait_methods.push(quote! {
-            fn build<I, O>(&self, req: I) -> Result<twirp::RequestBuilder<I, O>, twirp::ClientError>
-            where
-                I: prost::Message,
-                O: prost::Message + Default;
-        });
-        client_methods.push(quote! {
-            async fn request<I, O>(&self, req: twirp::RequestBuilder<I, O>) -> Result<O, twirp::ClientError>
-            where
-                I: prost::Message,
-                O: prost::Message + Default {
-                self.make_request(req).await
-            }
-        });
-        client_methods.push(quote! {
-            fn build<I, O>(&self, req: I) -> Result<twirp::RequestBuilder<I, O>, twirp::ClientError>
-            where
-                I: prost::Message,
-                O: prost::Message + Default {
-                    todo!()
-            }
-        });
         for m in &service.methods {
             let name = &m.name;
             let build_name = format_ident!("build_{}", name);
@@ -200,10 +172,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
             let request_path = format!("{}/{}", service.fqn, m.proto_name);
 
             client_trait_methods.push(quote! {
-                async fn #name(&self, req: #input_type) -> Result<#output_type, twirp::ClientError> {
-                    let builder = self.#build_name(req)?;
-                    self.request(builder).await
-                }
+                async fn #name(&self, req: #input_type) -> Result<#output_type, twirp::ClientError>;
             });
             client_trait_methods.push(quote! {
                 fn #build_name(&self, req: #input_type) -> Result<twirp::RequestBuilder<#input_type, #output_type>, twirp::ClientError>;
@@ -212,6 +181,12 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
             client_methods.push(quote! {
                 fn #build_name(&self, req: #input_type) -> Result<twirp::RequestBuilder<#input_type, #output_type>, twirp::ClientError> {
                     self.build_request(#request_path, req)
+                }
+            });
+            client_methods.push(quote! {
+                async fn #name(&self, req: #input_type) -> Result<#output_type, twirp::ClientError> {
+                    let builder = self.#build_name(req)?;
+                    self.request(builder).await
                 }
             });
         }

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -172,7 +172,9 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
             let request_path = format!("{}/{}", service.fqn, m.proto_name);
 
             client_trait_methods.push(quote! {
-                async fn #name(&self, req: #input_type) -> Result<#output_type, twirp::ClientError>;
+                async fn #name(&self, req: #input_type) -> Result<#output_type, twirp::ClientError> {
+                    self.#name_request(req)?.send().await
+                }
             });
             client_trait_methods.push(quote! {
                 fn #name_request(&self, req: #input_type) -> Result<twirp::RequestBuilder<#input_type, #output_type>, twirp::ClientError>;
@@ -181,11 +183,6 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
             client_methods.push(quote! {
                 fn #name_request(&self, req: #input_type) -> Result<twirp::RequestBuilder<#input_type, #output_type>, twirp::ClientError> {
                     self.request(#request_path, req)
-                }
-            });
-            client_methods.push(quote! {
-                async fn #name(&self, req: #input_type) -> Result<#output_type, twirp::ClientError> {
-                    self.#name_request(req)?.send().await
                 }
             });
         }

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -165,16 +165,35 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         let mut client_trait_methods = Vec::with_capacity(service.methods.len());
         let mut client_methods = Vec::with_capacity(service.methods.len());
         client_trait_methods.push(quote! {
-            async fn request<O>(&self, req: twirp::reqwest::RequestBuilder) -> Result<O, twirp::ClientError> where O: prost::Message + Default;
+            async fn request<I, O>(&self, req: twirp::RequestBuilder<I, O>) -> Result<O, twirp::ClientError>
+            where
+                I: prost::Message,
+                O: prost::Message + Default;
+        });
+        client_trait_methods.push(quote! {
+            fn build<I, O>(&self, req: I) -> Result<twirp::RequestBuilder<I, O>, twirp::ClientError>
+            where
+                I: prost::Message,
+                O: prost::Message + Default;
         });
         client_methods.push(quote! {
-            async fn request<O>(&self, req: twirp::reqwest::RequestBuilder) -> Result<O, twirp::ClientError> where O: prost::Message + Default {
+            async fn request<I, O>(&self, req: twirp::RequestBuilder<I, O>) -> Result<O, twirp::ClientError>
+            where
+                I: prost::Message,
+                O: prost::Message + Default {
                 self.make_request(req).await
+            }
+        });
+        client_methods.push(quote! {
+            fn build<I, O>(&self, req: I) -> Result<twirp::RequestBuilder<I, O>, twirp::ClientError>
+            where
+                I: prost::Message,
+                O: prost::Message + Default {
+                    todo!()
             }
         });
         for m in &service.methods {
             let name = &m.name;
-            // let name_ext = format_ident!("{}_ext", name);
             let build_name = format_ident!("build_{}", name);
             let input_type = &m.input_type;
             let output_type = &m.output_type;
@@ -186,20 +205,12 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
                     self.request(builder).await
                 }
             });
-            // client_trait_methods.push(quote! {
-            //     async fn #name_ext(&self, req: twirp::reqwest::RequestBuilder) -> Result<#output_type, twirp::ClientError>;
-            // });
             client_trait_methods.push(quote! {
-                fn #build_name(&self, req: #input_type) -> Result<twirp::reqwest::RequestBuilder, twirp::ClientError>;
+                fn #build_name(&self, req: #input_type) -> Result<twirp::RequestBuilder<#input_type, #output_type>, twirp::ClientError>;
             });
 
-            // client_methods.push(quote! {
-            //     async fn #name_ext(&self, req: twirp::reqwest::RequestBuilder) -> Result<#output_type, twirp::ClientError> {
-            //         self.request(req).await
-            //     }
-            // });
             client_methods.push(quote! {
-                fn #build_name(&self, req: #input_type) -> Result<twirp::reqwest::RequestBuilder, twirp::ClientError> {
+                fn #build_name(&self, req: #input_type) -> Result<twirp::RequestBuilder<#input_type, #output_type>, twirp::ClientError> {
                     self.build_request(#request_path, req)
                 }
             });

--- a/crates/twirp/src/client.rs
+++ b/crates/twirp/src/client.rs
@@ -177,8 +177,7 @@ impl Client {
     }
 
     /// Make an HTTP twirp request.
-    // pub async fn request<I, O>(&self, ctx: Context, path: &str, body: I) -> Result<O>
-    pub async fn make_request<I, O>(&self, builder: RequestBuilder<I, O>) -> Result<O>
+    pub async fn request<I, O>(&self, builder: RequestBuilder<I, O>) -> Result<O>
     where
         I: prost::Message,
         O: prost::Message + Default,
@@ -221,7 +220,6 @@ impl Client {
 
 pub struct RequestBuilder<I, O> {
     inner: reqwest::RequestBuilder,
-    host: Option<String>,
     _input: std::marker::PhantomData<I>,
     _output: std::marker::PhantomData<O>,
 }
@@ -230,7 +228,6 @@ impl<I, O> RequestBuilder<I, O> {
     pub fn new(inner: reqwest::RequestBuilder) -> Self {
         Self {
             inner,
-            host: None,
             _input: std::marker::PhantomData,
             _output: std::marker::PhantomData,
         }

--- a/crates/twirp/src/client.rs
+++ b/crates/twirp/src/client.rs
@@ -195,7 +195,9 @@ impl Client {
         }
     }
 
-    // Start building a request...
+    /// Start building a `Request` with a path and a request body.
+    ///
+    /// Returns a `RequestBuilder`, which will allow setting headers before sending.
     pub fn request<I, O>(&self, path: &str, body: I) -> Result<RequestBuilder<I, O>>
     where
         I: prost::Message,

--- a/crates/twirp/src/client.rs
+++ b/crates/twirp/src/client.rs
@@ -146,8 +146,6 @@ impl Client {
         &self.inner.base_url
     }
 
-    // TODO: Move this to the `ClientBuilder`
-    //
     /// Creates a new `twirp::Client` with the same configuration as the current
     /// one, but with a different host in the base URL.
     pub fn with_host(&self, host: &str) -> Self {
@@ -158,6 +156,7 @@ impl Client {
         }
     }
 
+    /// Executes a `Request`.
     pub(super) async fn execute<O>(&self, req: reqwest::Request) -> Result<O>
     where
         O: prost::Message + Default,
@@ -239,6 +238,7 @@ where
         }
     }
 
+    /// Add a `Header` to this Request.
     pub fn header<K, V>(mut self, key: K, value: V) -> RequestBuilder<I, O>
     where
         HeaderName: TryFrom<K>,

--- a/crates/twirp/src/lib.rs
+++ b/crates/twirp/src/lib.rs
@@ -10,7 +10,7 @@ pub mod test;
 #[doc(hidden)]
 pub mod details;
 
-pub use client::{Client, ClientBuilder, ClientError, Middleware, Next, Result};
+pub use client::{Client, ClientBuilder, ClientError, Middleware, Next, RequestBuilder, Result};
 pub use context::Context;
 pub use error::*; // many constructors like `invalid_argument()`
 pub use http::Extensions;

--- a/crates/twirp/src/test.rs
+++ b/crates/twirp/src/test.rs
@@ -122,7 +122,7 @@ pub trait TestApiClient {
 impl TestApiClient for Client {
     async fn ping(&self, req: PingRequest) -> Result<PingResponse> {
         let req = self.build_request("test.TestAPI/Ping", req)?;
-        self.make_request(req).await
+        self.request(req).await
     }
 
     async fn boom(&self, _req: PingRequest) -> Result<PingResponse> {

--- a/crates/twirp/src/test.rs
+++ b/crates/twirp/src/test.rs
@@ -121,7 +121,8 @@ pub trait TestApiClient {
 #[async_trait]
 impl TestApiClient for Client {
     async fn ping(&self, req: PingRequest) -> Result<PingResponse> {
-        self.request("test.TestAPI/Ping", req).await
+        let req = self.build_request("test.TestAPI/Ping", req)?;
+        self.make_request(req).await
     }
 
     async fn boom(&self, _req: PingRequest) -> Result<PingResponse> {

--- a/crates/twirp/src/test.rs
+++ b/crates/twirp/src/test.rs
@@ -121,8 +121,7 @@ pub trait TestApiClient {
 #[async_trait]
 impl TestApiClient for Client {
     async fn ping(&self, req: PingRequest) -> Result<PingResponse> {
-        let req = self.build_request("test.TestAPI/Ping", req)?;
-        self.request(req).await
+        self.request("test.TestAPI/Ping", req)?.send().await
     }
 
     async fn boom(&self, _req: PingRequest) -> Result<PingResponse> {

--- a/example/src/bin/client.rs
+++ b/example/src/bin/client.rs
@@ -1,6 +1,6 @@
 use twirp::async_trait::async_trait;
 use twirp::client::{Client, ClientBuilder, Middleware, Next};
-use twirp::reqwest::{self, Request, Response};
+use twirp::reqwest::{Request, Response};
 use twirp::url::Url;
 use twirp::GenericError;
 
@@ -44,7 +44,7 @@ pub async fn main() -> Result<(), GenericError> {
         .build_make_hat(MakeHatRequest { inches: 1 })?
         .header("x-custom-header", "a");
     // Make a request with context
-    let resp: MakeHatResponse = client.request(req).await?;
+    let resp = client.request(req).await?;
     eprintln!("{:?}", resp);
 
     Ok(())
@@ -89,22 +89,32 @@ impl HaberdasherApiClient for MockHaberdasherApiClient {
     fn build_make_hat(
         &self,
         _req: MakeHatRequest,
-    ) -> Result<reqwest::RequestBuilder, twirp::ClientError> {
+    ) -> Result<twirp::RequestBuilder<MakeHatRequest, MakeHatResponse>, twirp::ClientError> {
         todo!()
     }
 
     fn build_get_status(
         &self,
         _req: GetStatusRequest,
-    ) -> Result<reqwest::RequestBuilder, twirp::ClientError> {
+    ) -> Result<twirp::RequestBuilder<GetStatusRequest, GetStatusResponse>, twirp::ClientError>
+    {
         todo!()
     }
 
-    async fn request<O>(
+    async fn request<I, O>(
         &self,
-        _req: reqwest::RequestBuilder,
+        _req: twirp::RequestBuilder<I, O>,
     ) -> Result<O, twirp::client::ClientError>
     where
+        I: prost::Message,
+        O: prost::Message + Default,
+    {
+        todo!()
+    }
+
+    fn build<I, O>(&self, _req: I) -> Result<twirp::RequestBuilder<I, O>, twirp::ClientError>
+    where
+        I: prost::Message,
         O: prost::Message + Default,
     {
         todo!()

--- a/example/src/bin/client.rs
+++ b/example/src/bin/client.rs
@@ -80,6 +80,8 @@ impl Middleware for PrintResponseHeaders {
 
 // NOTE: This is just to demonstrate manually implementing the client trait. You don't need to do this as this code will
 // be generated for you by twirp-build.
+//
+// This is here so that we can visualize changes to the generated client code
 #[allow(dead_code)]
 #[derive(Debug)]
 struct MockHaberdasherApiClient;
@@ -92,6 +94,9 @@ impl HaberdasherApiClient for MockHaberdasherApiClient {
     ) -> Result<twirp::RequestBuilder<MakeHatRequest, MakeHatResponse>, twirp::ClientError> {
         todo!()
     }
+    async fn make_hat(&self, _req: MakeHatRequest) -> Result<MakeHatResponse, twirp::ClientError> {
+        todo!()
+    }
 
     fn build_get_status(
         &self,
@@ -100,23 +105,10 @@ impl HaberdasherApiClient for MockHaberdasherApiClient {
     {
         todo!()
     }
-
-    async fn request<I, O>(
+    async fn get_status(
         &self,
-        _req: twirp::RequestBuilder<I, O>,
-    ) -> Result<O, twirp::client::ClientError>
-    where
-        I: prost::Message,
-        O: prost::Message + Default,
-    {
-        todo!()
-    }
-
-    fn build<I, O>(&self, _req: I) -> Result<twirp::RequestBuilder<I, O>, twirp::ClientError>
-    where
-        I: prost::Message,
-        O: prost::Message + Default,
-    {
+        _req: GetStatusRequest,
+    ) -> Result<GetStatusResponse, twirp::ClientError> {
         todo!()
     }
 }

--- a/example/src/bin/client.rs
+++ b/example/src/bin/client.rs
@@ -93,6 +93,7 @@ impl HaberdasherApiClient for MockHaberdasherApiClient {
     ) -> Result<twirp::RequestBuilder<MakeHatRequest, MakeHatResponse>, twirp::ClientError> {
         todo!()
     }
+    // implementing this one is optional
     async fn make_hat(&self, _req: MakeHatRequest) -> Result<MakeHatResponse, twirp::ClientError> {
         todo!()
     }
@@ -104,6 +105,7 @@ impl HaberdasherApiClient for MockHaberdasherApiClient {
     {
         todo!()
     }
+    // implementing this one is optional
     async fn get_status(
         &self,
         _req: GetStatusRequest,

--- a/example/src/bin/client.rs
+++ b/example/src/bin/client.rs
@@ -1,6 +1,6 @@
 use twirp::async_trait::async_trait;
 use twirp::client::{Client, ClientBuilder, Middleware, Next};
-use twirp::reqwest::{Request, Response};
+use twirp::reqwest::{self, Request, Response};
 use twirp::url::Url;
 use twirp::GenericError;
 
@@ -38,6 +38,15 @@ pub async fn main() -> Result<(), GenericError> {
         .await;
     eprintln!("{:?}", resp);
 
+    // TODO: Figure out where `with_host` goes in all this...
+    let req = client
+        .with_host("localhost")
+        .build_make_hat(MakeHatRequest { inches: 1 })?
+        .header("x-custom-header", "a");
+    // Make a request with context
+    let resp: MakeHatResponse = client.request(req).await?;
+    eprintln!("{:?}", resp);
+
     Ok(())
 }
 
@@ -69,23 +78,35 @@ impl Middleware for PrintResponseHeaders {
     }
 }
 
+// NOTE: This is just to demonstrate manually implementing the client trait. You don't need to do this as this code will
+// be generated for you by twirp-build.
 #[allow(dead_code)]
 #[derive(Debug)]
 struct MockHaberdasherApiClient;
 
 #[async_trait]
 impl HaberdasherApiClient for MockHaberdasherApiClient {
-    async fn make_hat(
+    fn build_make_hat(
         &self,
         _req: MakeHatRequest,
-    ) -> Result<MakeHatResponse, twirp::client::ClientError> {
+    ) -> Result<reqwest::RequestBuilder, twirp::ClientError> {
         todo!()
     }
 
-    async fn get_status(
+    fn build_get_status(
         &self,
         _req: GetStatusRequest,
-    ) -> Result<GetStatusResponse, twirp::client::ClientError> {
+    ) -> Result<reqwest::RequestBuilder, twirp::ClientError> {
+        todo!()
+    }
+
+    async fn request<O>(
+        &self,
+        _req: reqwest::RequestBuilder,
+    ) -> Result<O, twirp::client::ClientError>
+    where
+        O: prost::Message + Default,
+    {
         todo!()
     }
 }

--- a/example/src/bin/client.rs
+++ b/example/src/bin/client.rs
@@ -38,13 +38,12 @@ pub async fn main() -> Result<(), GenericError> {
         .await;
     eprintln!("{:?}", resp);
 
-    // TODO: Figure out where `with_host` goes in all this...
-    let req = client
+    let resp = client
         .with_host("localhost")
-        .build_make_hat(MakeHatRequest { inches: 1 })?
-        .header("x-custom-header", "a");
-    // Make a request with context
-    let resp = client.request(req).await?;
+        .make_hat_request(MakeHatRequest { inches: 1 })?
+        .header("x-custom-header", "a")
+        .send()
+        .await?;
     eprintln!("{:?}", resp);
 
     Ok(())
@@ -88,7 +87,7 @@ struct MockHaberdasherApiClient;
 
 #[async_trait]
 impl HaberdasherApiClient for MockHaberdasherApiClient {
-    fn build_make_hat(
+    fn make_hat_request(
         &self,
         _req: MakeHatRequest,
     ) -> Result<twirp::RequestBuilder<MakeHatRequest, MakeHatResponse>, twirp::ClientError> {
@@ -98,7 +97,7 @@ impl HaberdasherApiClient for MockHaberdasherApiClient {
         todo!()
     }
 
-    fn build_get_status(
+    fn get_status_request(
         &self,
         _req: GetStatusRequest,
     ) -> Result<twirp::RequestBuilder<GetStatusRequest, GetStatusResponse>, twirp::ClientError>


### PR DESCRIPTION
@look is working on something that requires adding custom headers to the twirp request. This is sort of possible today with middleware, but it is a bit awkward and not at all easy to do if you need those headers to be based on other application state. 

This is one idea for allowing the twirp clients to set additional request data. I've tried to make this backward compatible.

I did consider some alternative designs:

- Introducing `Context` like we do for the twirp servers. I don't love this pattern, it feels like Go, so I'm opting not to continue in that direction.