### PR TITLE
Generate service fqn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twirp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "twirp-build"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp-build"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Code generation for async-compatible Twirp RPC interfaces."
 readme = "README.md"

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -128,7 +128,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         for m in &service.methods {
             let name = &m.name;
             let input_type = &m.input_type;
-            let path = format!("/{uri}", uri = m.proto_name);
+            let path = format!("/{}/{}", &service.fqn, m.proto_name);
 
             route_calls.push(quote! {
                 .route(#path, |api: T, req: twirp::Request<#input_type>| async move {

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -89,6 +89,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         let service = Service::from_prost(service);
 
         // generate the twirp server
+        let service_fqn_path = format!("/{}", service.fqn);
         let mut trait_methods = Vec::with_capacity(service.methods.len());
         let mut proxy_methods = Vec::with_capacity(service.methods.len());
         for m in &service.methods {
@@ -128,7 +129,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         for m in &service.methods {
             let name = &m.name;
             let input_type = &m.input_type;
-            let path = format!("/{}/{}", &service.fqn, m.proto_name);
+            let path = format!("/{}", m.proto_name);
 
             route_calls.push(quote! {
                 .route(#path, |api: T, req: twirp::Request<#input_type>| async move {
@@ -141,7 +142,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
                 where
                     T: #rpc_trait_name + Clone + Send + Sync + 'static
                 {
-                    twirp::details::TwirpRouterBuilder::new(api)
+                    twirp::details::TwirpRouterBuilder::new(#service_fqn_path, api)
                         #(#route_calls)*
                         .build()
                 }
@@ -172,7 +173,6 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
 
         // generate the service and client as a single file. run it through
         // prettyplease before outputting it.
-        let service_fqn_path = format!("/{}", service.fqn);
         let generated = quote! {
             pub use twirp;
 

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "An async-compatible library for Twirp RPC in Rust."
 readme = "README.md"

--- a/crates/twirp/README.md
+++ b/crates/twirp/README.md
@@ -66,10 +66,8 @@ use haberdash::{MakeHatRequest, MakeHatResponse};
 #[tokio::main]
 pub async fn main() {
     let api_impl = Arc::new(HaberdasherApiServer {});
-    let twirp_routes = Router::new()
-        .nest(haberdash::SERVICE_FQN, haberdash::router(api_impl));
     let app = Router::new()
-        .nest("/twirp", twirp_routes)
+        .nest("/twirp", haberdash::router(api_impl))
         .fallback(twirp::server::not_found_handler);
 
     let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await.unwrap();

--- a/crates/twirp/src/details.rs
+++ b/crates/twirp/src/details.rs
@@ -27,13 +27,6 @@ where
         }
     }
 
-    pub fn service(self, path: &str) -> Self {
-        TwirpRouterBuilder {
-            service: self.service,
-            router: Router::new().nest(path, self.router),
-        }
-    }
-
     /// Add a handler for an `rpc` to the router.
     ///
     /// The generated code passes a closure that calls the method, like

--- a/crates/twirp/src/details.rs
+++ b/crates/twirp/src/details.rs
@@ -27,6 +27,13 @@ where
         }
     }
 
+    pub fn service(self, path: &str) -> Self {
+        TwirpRouterBuilder {
+            service: self.service,
+            router: Router::new().nest(path, self.router),
+        }
+    }
+
     /// Add a handler for an `rpc` to the router.
     ///
     /// The generated code passes a closure that calls the method, like

--- a/crates/twirp/src/test.rs
+++ b/crates/twirp/src/test.rs
@@ -33,13 +33,13 @@ pub fn test_api_router() -> Router {
     // NB: This part would be generated
     let test_router = TwirpRouterBuilder::new(api)
         .route(
-            "/Ping",
+            "/test.TestAPI/Ping",
             |api: Arc<TestApiServer>, req: http::Request<PingRequest>| async move {
                 api.ping(req).await
             },
         )
         .route(
-            "/Boom",
+            "/test.TestAPI/Boom",
             |api: Arc<TestApiServer>, req: http::Request<PingRequest>| async move {
                 api.boom(req).await
             },
@@ -47,7 +47,7 @@ pub fn test_api_router() -> Router {
         .build();
 
     axum::Router::new()
-        .nest("/twirp/test.TestAPI", test_router)
+        .nest("/twirp", test_router)
         .fallback(crate::server::not_found_handler)
 }
 

--- a/crates/twirp/src/test.rs
+++ b/crates/twirp/src/test.rs
@@ -31,15 +31,15 @@ pub fn test_api_router() -> Router {
     let api = Arc::new(TestApiServer {});
 
     // NB: This part would be generated
-    let test_router = TwirpRouterBuilder::new(api)
+    let test_router = TwirpRouterBuilder::new("/test.TestAPI", api)
         .route(
-            "/test.TestAPI/Ping",
+            "/Ping",
             |api: Arc<TestApiServer>, req: http::Request<PingRequest>| async move {
                 api.ping(req).await
             },
         )
         .route(
-            "/test.TestAPI/Boom",
+            "/Boom",
             |api: Arc<TestApiServer>, req: http::Request<PingRequest>| async move {
                 api.boom(req).await
             },

--- a/example/src/bin/advanced-server.rs
+++ b/example/src/bin/advanced-server.rs
@@ -41,9 +41,7 @@ pub async fn main() {
     let api_impl = HaberdasherApiServer {};
     let middleware = twirp::tower::builder::ServiceBuilder::new()
         .layer(middleware::from_fn(request_id_middleware));
-    let twirp_routes = Router::new()
-        .nest(haberdash::SERVICE_FQN, haberdash::router(api_impl))
-        .layer(middleware);
+    let twirp_routes = haberdash::router(api_impl).layer(middleware);
     let app = Router::new()
         .nest("/twirp", twirp_routes)
         .route("/_ping", get(ping))
@@ -178,10 +176,8 @@ mod test {
 
     impl NetServer {
         async fn start(api_impl: HaberdasherApiServer) -> Self {
-            let twirp_routes =
-                Router::new().nest(haberdash::SERVICE_FQN, haberdash::router(api_impl));
             let app = Router::new()
-                .nest("/twirp", twirp_routes)
+                .nest("/twirp", haberdash::router(api_impl))
                 .route("/_ping", get(ping))
                 .fallback(twirp::server::not_found_handler);
 

--- a/example/src/bin/simple-server.rs
+++ b/example/src/bin/simple-server.rs
@@ -34,9 +34,8 @@ async fn ping() -> &'static str {
 #[tokio::main]
 pub async fn main() {
     let api_impl = HaberdasherApiServer {};
-    let twirp_routes = Router::new().nest(haberdash::SERVICE_FQN, haberdash::router(api_impl));
     let app = Router::new()
-        .nest("/twirp", twirp_routes)
+        .nest("/twirp", haberdash::router(api_impl))
         .route("/_ping", get(ping))
         .fallback(twirp::server::not_found_handler);
 
@@ -138,10 +137,8 @@ mod test {
 
     impl NetServer {
         async fn start(api_impl: HaberdasherApiServer) -> Self {
-            let twirp_routes =
-                Router::new().nest(haberdash::SERVICE_FQN, haberdash::router(api_impl));
             let app = Router::new()
-                .nest("/twirp", twirp_routes)
+                .nest("/twirp", haberdash::router(api_impl))
                 .route("/_ping", get(ping))
                 .fallback(twirp::server::not_found_handler);
 


### PR DESCRIPTION
Today, server consumers of this library have to know how to properly construct the fully qualified service path by using `nest` on an axum Router like so:

```rust
let twirp_routes = Router::new()
        .nest(haberdash::SERVICE_FQN, haberdash::router(api_impl));
```

This patch makes that unnecessary (the generated `router` function for each service does that for you). Instead, you would write:
``` rust
let twirp_routes = haberdash::router(api_impl);
```


It is still canonical (but not required) to then nest with a `/twirp` prefix (the examples show this).

⚠️ this is a breaking change as applications will need to remove any manual service nesting they are doing today.