### PR TITLE
Remove `SERVICE_FQN` to avoid upgrade confusion

### DIFF
--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -209,7 +209,7 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
                 async fn handle(&self, method: &str, req: twirp::reqwest::Request) -> twirp::Result<twirp::reqwest::Response> {
                     match method {
                         #(#method_matches)*
-                        _ => Err(twirp::bad_route(format!("unknown rpc `{method}` for service `{}`, url: {:?}", super::SERVICE_FQN, req.url()))),
+                        _ => Err(twirp::bad_route(format!("unknown rpc `{method}` for service `{}`, url: {:?}", #service_fqn, req.url()))),
                     }
                 }
             }
@@ -228,8 +228,6 @@ impl prost_build::ServiceGenerator for ServiceGenerator {
         // prettyplease before outputting it.
         let generated = quote! {
             pub use twirp;
-
-            pub const SERVICE_FQN: &str = #service_fqn_path;
 
             #server_trait
 


### PR DESCRIPTION
As of https://github.com/github/twirp-rs/pull/221, you should not use `SERVICE_FQN` to wire up routes because the library now does this automatically. This PR removes the const entirely so that library users don't accidentally double nest routes.