### PR TITLE
Include the readme in rustdoc

### DIFF
--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../../twirp/README.md")]
+
 use quote::{format_ident, quote};
 
 /// Generates twirp services for protobuf rpc service definitions.

--- a/crates/twirp-build/src/lib.rs
+++ b/crates/twirp-build/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../twirp/README.md")]
+#![doc = include_str!("../README.md")]
 
 use quote::{format_ident, quote};
 

--- a/crates/twirp/README.md
+++ b/crates/twirp/README.md
@@ -1,4 +1,4 @@
-# `twirp-build`
+# `twirp`
 
 [Twirp is an RPC protocol](https://twitchtv.github.io/twirp/docs/spec_v7.html) based on HTTP and Protocol Buffers (proto). The protocol uses HTTP URLs to specify the RPC endpoints, and sends/receives proto messages as HTTP request/response bodies. Services are defined in a [.proto file](https://developers.google.com/protocol-buffers/docs/proto3), allowing easy implementation of RPC services with auto-generated clients and servers in different languages.
 

--- a/crates/twirp/README.md
+++ b/crates/twirp/README.md
@@ -34,7 +34,11 @@ prost-build = "0.13"
 
 Add a `build.rs` file to your project to compile the protos and generate Rust code:
 
-```rust
+<!--
+`rust` gets syntax highlighting in GitHub UI and Rustdoc contexts
+` ,ignore` (including the space) makes rust tests ignore the code without breaking syntax highlighting
+-->
+```rust ,ignore
 fn main() {
     let proto_source_files = ["./service.proto"];
 
@@ -55,7 +59,11 @@ This generates code that you can find in `target/build/your-project-*/out/exampl
 
 Include the generated code, create a router, register your service, and then serve those routes in the hyper server:
 
-```rust
+<!--
+`rust` gets syntax highlighting in GitHub UI and Rustdoc contexts
+` ,ignore` (including the space) makes rust tests ignore the code without breaking syntax highlighting
+-->
+```rust ,ignore
 mod haberdash {
     include!(concat!(env!("OUT_DIR"), "/service.haberdash.v1.rs"));
 }
@@ -93,7 +101,11 @@ This code creates an `axum::Router`, then hands it off to `axum::serve()` to han
 
 On the client side, you also get a generated twirp client (based on the rpc endpoints in your proto). Include the generated code, create a client, and start making rpc calls:
 
-``` rust
+<!--
+`rust` gets syntax highlighting in GitHub UI and Rustdoc contexts
+` ,ignore` (including the space) makes rust tests ignore the code without breaking syntax highlighting
+-->
+```rust ,ignore
 mod haberdash {
     include!(concat!(env!("OUT_DIR"), "/service.haberdash.v1.rs"));
 }

--- a/crates/twirp/src/lib.rs
+++ b/crates/twirp/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 pub mod client;
 pub mod error;
 pub mod headers;


### PR DESCRIPTION
Replaces #12 

Here's what the `twirp` rustdoc page looks like:

<img width="720" height="536" alt="image" src="https://github.com/user-attachments/assets/58b68b9c-16d5-49f7-b7e7-75d8f4ea774e" />

Here's what the `twirp-build` rustdoc page looks like:

<img width="1422" height="651" alt="image" src="https://github.com/user-attachments/assets/f7f7e55a-c864-4be1-8f2d-d466f0765730" />
