### PR TITLE
Prep for 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twirp"
-version = "0.11.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "twirp-build"
-version = "0.11.0"
+version = "0.8.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp-build"
-version = "0.11.0"
+version = "0.8.0"
 edition = "2021"
 description = "Code generation for async-compatible Twirp RPC interfaces."
 readme = "README.md"

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twirp"
-version = "0.11.0"
+version = "0.8.0"
 edition = "2021"
 description = "An async-compatible library for Twirp RPC in Rust."
 readme = "README.md"


### PR DESCRIPTION
I would like to try out the automated workflow for generating the 0.9.0 PR & publishing. In order to do that, the version in the repo needs to match the version in crates.io:

<img width="655" height="143" alt="image" src="https://github.com/user-attachments/assets/4912e5a5-d37c-4373-aa9e-6cba5c1c29aa" />
