### PR TITLE
Preserve HTTP version in twirp client response

### DIFF
--- a/crates/twirp/src/client.rs
+++ b/crates/twirp/src/client.rs
@@ -220,6 +220,7 @@ impl Client {
         let response = next.run(request).await?;
 
         // These have to be extracted because reading the body consumes `Response`.
+        let version = response.version();
         let status = response.status();
         let headers = response.headers().clone();
         let extensions = response.extensions().clone();
@@ -231,6 +232,7 @@ impl Client {
                 O::decode(response.bytes().await?)
                     .map(|x| {
                         let mut resp = http::Response::new(x);
+                        *resp.version_mut() = version;
                         resp.headers_mut().extend(headers);
                         resp.extensions_mut().extend(extensions);
                         resp


### PR DESCRIPTION
# Motivation

While testing the http/2 rollout I noticed that there was a up-tick in HTTP/2 requests coming in but the client send metrics were all saying HTTP/1.1. 

It turns out this is because we were manually reconstructing a `http::Response` in the twirp client, without propagating the version.

# Implementation

Copied across the version like we do with the status etc.