### PR TITLE
Move http client on twirp client build to its own method.

### DIFF
--- a/example/src/bin/client.rs
+++ b/example/src/bin/client.rs
@@ -39,13 +39,10 @@ pub async fn main() -> Result<(), GenericError> {
     eprintln!("{:?}", resp);
 
     // customize the client with middleware
-    let client = ClientBuilder::new(
-        Url::parse("http://xyz:3000/twirp/")?,
-        twirp::reqwest::Client::default(),
-    )
-    .with_middleware(RequestHeaders { hmac_key: None })
-    .with_middleware(PrintResponseHeaders {})
-    .build();
+    let client = ClientBuilder::new(Url::parse("http://xyz:3000/twirp/")?)
+        .with_middleware(RequestHeaders { hmac_key: None })
+        .with_middleware(PrintResponseHeaders {})
+        .build();
     let resp = client
         .with_host("localhost")
         .make_hat(Request::new(MakeHatRequest { inches: 1 }))


### PR DESCRIPTION
This is helpful because there are times you need to set the http client  when in direct mode. E.g. you want to preload a load of default headers.

Changed the `ClientBuilder::new` to no longer take the http client, they can use the method if they need it. This is a minor breaking change but should be easy to port.

Uses `Option<Client>` in the build because building a HTTP client is non-trivial so it's nicer to not do it twice in the case where you want to use a custom client.