### PR TITLE
Map reqwest errors to semantically correct Twirp error codes

### DIFF
--- a/crates/twirp/src/error.rs
+++ b/crates/twirp/src/error.rs
@@ -407,12 +407,20 @@ mod test {
 
     #[tokio::test]
     async fn reqwest_timeout_error_maps_to_unavailable() {
+        // Bind a listener that accepts but never responds, guaranteeing a timeout.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _accept_thread = std::thread::spawn(move || {
+            let (_stream, _) = listener.accept().unwrap();
+            std::thread::sleep(std::time::Duration::from_secs(60));
+        });
+
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_nanos(1))
+            .timeout(std::time::Duration::from_millis(1))
             .build()
             .unwrap();
         let err = client
-            .get("http://192.0.2.1") // RFC 5737 TEST-NET, non-routable
+            .get(format!("http://{addr}"))
             .send()
             .await
             .unwrap_err();
@@ -422,7 +430,7 @@ mod test {
 
     #[test]
     fn reqwest_builder_error_maps_to_invalid_argument() {
-        // An invalid URL scheme triggers a builder error
+        // An empty URL string triggers a builder error
         let err = reqwest::Client::builder()
             .build()
             .unwrap()

--- a/crates/twirp/src/error.rs
+++ b/crates/twirp/src/error.rs
@@ -258,10 +258,21 @@ impl From<serde_json::Error> for TwirpErrorResponse {
     }
 }
 
-// unable to build the request
+// Map reqwest errors to semantically appropriate Twirp error codes.
+// Transport failures (connect, timeout) → Unavailable (retryable).
+// Request-building errors → InvalidArgument (caller's fault).
+// Response-parsing errors → Internal (unexpected server behavior).
 impl From<reqwest::Error> for TwirpErrorResponse {
     fn from(e: reqwest::Error) -> Self {
-        invalid_argument(e.to_string()).with_rust_error(e)
+        let msg = e.to_string();
+        if e.is_builder() {
+            invalid_argument(msg).with_rust_error(e)
+        } else if e.is_redirect() || e.is_body() || e.is_decode() {
+            internal(msg).with_rust_error(e)
+        } else {
+            // connect, timeout, request, and anything else — treat as transient
+            unavailable(msg).with_rust_error(e)
+        }
     }
 }
 
@@ -391,6 +402,34 @@ mod test {
 
         let result = serde_json::from_str(&result).unwrap();
         assert_eq!(response, result);
+    }
+
+    #[tokio::test]
+    async fn reqwest_timeout_error_maps_to_unavailable() {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_nanos(1))
+            .build()
+            .unwrap();
+        let err = client
+            .get("http://192.0.2.1") // RFC 5737 TEST-NET, non-routable
+            .send()
+            .await
+            .unwrap_err();
+        let twirp_err: TwirpErrorResponse = err.into();
+        assert_eq!(twirp_err.code, TwirpErrorCode::Unavailable);
+    }
+
+    #[test]
+    fn reqwest_builder_error_maps_to_invalid_argument() {
+        // An invalid URL scheme triggers a builder error
+        let err = reqwest::Client::builder()
+            .build()
+            .unwrap()
+            .get("")
+            .build()
+            .unwrap_err();
+        let twirp_err: TwirpErrorResponse = err.into();
+        assert_eq!(twirp_err.code, TwirpErrorCode::InvalidArgument);
     }
 
     #[test]

--- a/crates/twirp/src/error.rs
+++ b/crates/twirp/src/error.rs
@@ -265,14 +265,15 @@ impl From<serde_json::Error> for TwirpErrorResponse {
 impl From<reqwest::Error> for TwirpErrorResponse {
     fn from(e: reqwest::Error) -> Self {
         let msg = e.to_string();
-        if e.is_builder() {
-            invalid_argument(msg).with_rust_error(e)
+        let resp = if e.is_builder() {
+            invalid_argument(msg)
         } else if e.is_redirect() || e.is_body() || e.is_decode() {
-            internal(msg).with_rust_error(e)
+            internal(msg)
         } else {
             // connect, timeout, request, and anything else — treat as transient
-            unavailable(msg).with_rust_error(e)
-        }
+            unavailable(msg)
+        };
+        resp.with_rust_error(e)
     }
 }
 


### PR DESCRIPTION
The `From<reqwest::Error>` impl was mapping all reqwest errors to `InvalidArgument`, which is wrong for transport failures like connection refused, DNS resolution failures, and timeouts. Downstream consumers (e.g. retry logic) couldn't distinguish transient infrastructure failures from actual bad input.

## Approach

Replace the blanket mapping with variant-specific logic:

- **`is_builder()`** → `InvalidArgument` — actually malformed input (bad URL, etc.)
- **`is_redirect()` / `is_body()` / `is_decode()`** → `Internal` — unexpected server behavior or response parsing failure
- **everything else** (connect, timeout, request) → `Unavailable` — transient and retryable

The default is `Unavailable` rather than `Internal` because it's safer to assume a transport error is transient and retryable.

The `.with_rust_error(e)` pattern is preserved so the original reqwest error is available for debugging.

<sub>*Generated via Copilot (Claude Opus 4.6) on behalf of @tclem*</sub>