### PR TITLE
Change license metadata

### DIFF
--- a/crates/twirp-build/Cargo.toml
+++ b/crates/twirp-build/Cargo.toml
@@ -11,7 +11,7 @@ categories = [
     "asynchronous",
 ]
 repository = "https://github.com/github/twirp-rs"
-license-file = "./LICENSE"
+license = "MIT"
 
 [dependencies]
 prost-build = "0.14"

--- a/crates/twirp/Cargo.toml
+++ b/crates/twirp/Cargo.toml
@@ -11,7 +11,7 @@ categories = [
     "asynchronous",
 ]
 repository = "https://github.com/github/twirp-rs"
-license-file = "./LICENSE"
+license = "MIT"
 
 [features]
 test-support = []


### PR DESCRIPTION
*This is a change to Cargo.toml file metadata. The license isn't changing. It's still MIT, like it always has been.*

The Cargo book has a section that describes how these fields are supposed to be used: <https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields>

It says that the `license-file` key is for the case where "a package is using a nonstandard license". Since our license is MIT, we should use the `license` key (like almost all of the Cargo ecosystem).

(The history of these files shows we previously had both keys, but deleted `license` about a year ago, because apparently cargo warns if you have both :shrug:)